### PR TITLE
Hide dynamically created themes and color schemes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Install the `Themes Menu Switcher` from [Package Control](https://packagecontrol
 Themes can be activated from `Preferences -> Theme` menu.
 
 You can also open the command pallet with <kbd>Ctrl+Shift+P</kbd> and type:
-- `Set Theme`
-- `Set Color Scheme`
+- `Select Theme`
+- `Select Color Scheme`
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ You can also open the command pallet with <kbd>Ctrl+Shift+P</kbd> and type:
 - `Select Theme`
 - `Select Color Scheme`
 
+## Settings
+
+Some plugins dynamically create themes or color schemes which are not meant to
+be selected by a user. To hide those you can create a settings file
+`Theme-Switcher.sublime-settings` and add the pathes to `"colors_exclude"` or
+`"themes_exclude"` filter lists.
+
+```js
+{
+	"colors_exclude":
+	[
+		"Packages/User/SublimeLinter",
+		"Packages/User/Sublimerge"
+	],
+	"themes_exclude":
+	[
+		"Packages/zz File Icons/"
+	]
+}
+```
+
 ## Credits
 
 Credits to [@geekpradd](https://github.com/geekpradd) for idea, structure, and preamble.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,47 @@
 # Sublime Theme Switcher
+
 Switch Sublime Text themes on the fly using the `main menu` or `command pallet`
 
 ![scr](https://cloud.githubusercontent.com/assets/11352152/14230693/b6e33c28-f92f-11e5-8d6c-b2e32054f804.png)
 
 ## Preamble
-Sublime Text has many themes available for download from Package Control and many of them are very cool looking. But, there is a slight problem with the entire theme system on activating themes.
+
+Sublime Text has many themes available for download from Package Control and
+many of them are very cool looking. But, there is a slight problem with the
+entire theme system on activating themes.
 
 For example, let's say I am browsing for Themes on Package Control.
 
-I searched for Themes and I found the "Flatland" theme. I installed it directly from Sublime Text and then I want to try the theme out.
+I searched for Themes and I found the "Flatland" theme. I installed it
+directly from Sublime Text and then I want to try the theme out.
 
-Now the only way to do so, is to open my Preferences file, and modify it to activate Flatland.
+Now the only way to do so, is to open my Preferences file, and modify it to
+activate Flatland.
 
-So, in my preferences, I modified the `theme` key to become `Flatland.sublime-theme`. But the Theme did not activate.
+So, in my preferences, I modified the `theme` key to become
+`Flatland.sublime-theme`. But the Theme did not activate.
 
-Wait, why? Because the theme file is named `Flatland Dark.sublime-theme`. So to activate the Theme, I have to go to the Flatland GitHub page and then search for Instructions.
+Wait, why? Because the theme file is named `Flatland Dark.sublime-theme`.
+So to activate the Theme, I have to go to the Flatland GitHub page and then
+search for Instructions.
 
 So, just to activate a Theme, I have to do a lot of work.
 
-That's where Theme Switcher jumps in. Theme Switcher automatically adds your Themes to the Menu from which you can easily Activate your Themes. Theme Switcher also displays multiple variants of Themes so that you can use them all at ease. For example, all variants of the "Afterglow" Theme can be accessed and activated from the GUI itself.
+That's where Theme Switcher jumps in. Theme Switcher automatically adds your
+Themes to the Menu from which you can easily Activate your Themes. Theme
+Switcher also displays multiple variants of Themes so that you can use them
+all at ease. For example, all variants of the "Afterglow" Theme can be
+accessed and activated from the GUI itself.
 
 For ease of use, all themes and their variants are sorted alphabetically.
 
 ## Install
-Install the `Themes Menu Switcher` from [Package Control](https://packagecontrol.io/)
+
+Install the `Themes Menu Switcher` from
+[Package Control](https://packagecontrol.io/)
 
 ## Use
+
 Themes can be activated from `Preferences -> Theme` menu.
 
 You can also open the command pallet with <kbd>Ctrl+Shift+P</kbd> and type:
@@ -55,4 +71,5 @@ be selected by a user. To hide those you can create a settings file
 
 ## Credits
 
-Credits to [@geekpradd](https://github.com/geekpradd) for idea, structure, and preamble.
+Credits to [@geekpradd](https://github.com/geekpradd) for idea, structure, and
+preamble.

--- a/Theme-Switcher.sublime-settings
+++ b/Theme-Switcher.sublime-settings
@@ -1,0 +1,16 @@
+{
+	// Ignore color schemes whose path include one of the listed strings.
+	// This setting is used to hide dynamically created color schemes.
+	"colors_exclude":
+	[
+		"Packages/User/SublimeLinter",
+		"Packages/User/Sublimerge"
+	],
+
+	// Ignore themes whose path include one of the listed strings.
+	// This setting is mainly used to hide dynamically created themes.
+	"themes_exclude":
+	[
+		"Packages/zz File Icons/"
+	]
+}

--- a/theme_switcher.py
+++ b/theme_switcher.py
@@ -69,12 +69,14 @@ class RefreshThemeCacheCommand(sublime_plugin.ApplicationCommand):
     @staticmethod
     def create_menu(command, file_pattern):
         d = {}
-
+        settings = sublime.load_settings("Theme-Switcher.sublime-settings")
+        exclude_list = settings.get("themes_exclude", [])
         for path in sublime.find_resources(file_pattern):
-            elems = path.split("/")
-            # elems[1] package name
-            # elems[-1] theme file name
-            d.setdefault(elems[1], []).append(elems[-1])
+            if not any(exclude in path for exclude in exclude_list):
+                elems = path.split("/")
+                # elems[1] package name
+                # elems[-1] theme file name
+                d.setdefault(elems[1], []).append(elems[-1])
 
         menu = [{
             "caption": package_name,
@@ -125,11 +127,7 @@ class SwitchWindowCommandBase(sublime_plugin.WindowCommand):
             # so let the user choose from the list of existing ones.
             names, values = self.get_items()
             current_value = self.settings.get(self.KEY)
-
-            try:
-                selected_index = values.index(current_value)
-            except ValueError:
-                selected_index = -1
+            selected_index = self.get_selected(values, current_value)
 
             self.window.show_quick_panel(
                 items = names,
@@ -150,19 +148,39 @@ class SwitchThemeCommand(SwitchWindowCommandBase):
 
     @staticmethod
     def get_items():
-        """
-        Return a list of all themes to show in the quick panel.
+        """Return a list of quick panel items for all themes.
+
         The values are the basename of each *.sublime-theme.
+
+        NOTE: Excludes themes manipulated by zz File Icons as
+              they are automatically created and used if required.
         """
         names = []
         values = []
-        for path in sorted(sublime.find_resources("*.sublime-theme"), key = lambda x:os.path.basename(x)):
-            elems = path.split("/")
-            names.append([ built_res_name(elems[-1]),    # title
-                           "Package: " + elems[1] ])     # description
-            values.append(elems[-1])
-
+        settings = sublime.load_settings("Theme-Switcher.sublime-settings")
+        exclude_list = settings.get("themes_exclude", [])
+        paths = sorted(
+            sublime.find_resources("*.sublime-theme"),
+            key=lambda x: os.path.basename(x))
+        for path in paths:
+            if not any(exclude in path for exclude in exclude_list):
+                elems = path.split("/")
+                # elems[1] package name
+                # elems[-1] theme file name
+                names.append(
+                    [built_res_name(elems[-1]),    # title
+                     "Package: " + elems[1]])      # description
+                values.append(elems[-1])
         return [names, values]
+
+    @staticmethod
+    def get_selected(values, current_value):
+        """Return the index of the currenty active theme in <values>."""
+        try:
+            selected_index = values.index(current_value)
+        except ValueError:
+            selected_index = -1
+        return selected_index
 
 
 class SwitchColorSchemeCommand(SwitchWindowCommandBase):
@@ -170,16 +188,48 @@ class SwitchColorSchemeCommand(SwitchWindowCommandBase):
 
     @staticmethod
     def get_items():
-        """
-        Return a list of all color schemes to show in the quick panel.
+        """Return a list of quick panel items for all color schemes.
+
         The values are the full path of each *.tmTheme.
+
+        NOTE: Excludes color schemes manipulated by SublimeLinter as
+              they are automatically created and used if required.
         """
         names = []
         values = []
-        for path in sorted(sublime.find_resources("*.tmTheme"), key = lambda x:os.path.basename(x)):
-            elems = path.split("/")
-            names.append([ built_res_name(elems[-1]),    # title
-                           "Package: " + elems[1] ])     # description
-            values.append(path)
-
+        settings = sublime.load_settings("Theme-Switcher.sublime-settings")
+        exclude_list = settings.get("colors_exclude", [])
+        paths = sorted(
+            sublime.find_resources("*.tmTheme"),
+            key=lambda x: os.path.basename(x))
+        for path in paths:
+            if not any(exclude in path for exclude in exclude_list):
+                elems = path.split("/")
+                # elems[1] package name
+                # elems[-1] color scheme file name
+                names.append(
+                    [built_res_name(elems[-1]),    # title
+                     "Package: " + elems[1]])      # description
+                values.append(path)
         return [names, values]
+
+    @staticmethod
+    def get_selected(values, current_value):
+        """Return the index of the currenty active color scheme in <values>.
+
+        If the color scheme is not contained by values it might have been
+        automatically created and selected by SublimeLinter so we search
+        for the original one and return its index.
+        """
+        try:
+            selected_index = values.index(current_value)
+        except ValueError:
+            try:
+                # find the original color scheme for a sublimelinter hacked
+                original_scheme = current_value.replace(" (SL)", "")
+                original_scheme = os.path.basename(original_scheme)
+                original_scheme = sublime.find_resources(original_scheme)[-1]
+                selected_index = values.index(original_scheme)
+            except ValueError:
+                selected_index = -1
+        return selected_index

--- a/theme_switcher.py
+++ b/theme_switcher.py
@@ -47,8 +47,9 @@ class RefreshThemeCacheCommand(sublime_plugin.ApplicationCommand):
             }]
         }]
         # save main menu to file
-        with open(cache_path + "Main.sublime-menu", "w") as f:
-            f.write(sublime.encode_value(menu, False))
+        cache_path += "Main.sublime-menu"
+        with open(cache_path, "w", encoding="utf-8") as menu_file:
+            menu_file.write(sublime.encode_value(menu, False))
 
     @staticmethod
     def create_menu(command, file_pattern):
@@ -68,8 +69,7 @@ class RefreshThemeCacheCommand(sublime_plugin.ApplicationCommand):
                 "caption": built_res_name(theme),
                 "command": command,
                 "args": {"name": theme}
-            } for theme in sorted(
-                themes, key=lambda x: x.replace(".", " "))]
+            } for theme in themes]
         } for package_name, themes in sorted(d.items())]
 
         menu.append({"caption": "-", "id": "separator"})


### PR DESCRIPTION
Some plugins such as `SublimeLinter` or `Sublimerge` dynamically create modified color schemes based on the active one. They are required to support some features but cause issues if selected by user directly. At least they may confuse. The first commit implements methods to hide those color schemes and themes in the main menu and command pallet.

The following commits introduce code changes to satisfy pep8, pyflakes and pydocstyle linting rules.

