### PR TITLE
Fix: Save Preferences.sublime-settings on canceled 'Select ...', too.

### DIFF
--- a/theme_switcher.py
+++ b/theme_switcher.py
@@ -108,9 +108,9 @@ class SwitchWindowCommandBase(sublime_plugin.WindowCommand):
         def on_select(index):
             if -1 < index < len(values):
                 settings.set(self.KEY, values[index])
-                sublime.save_settings(settings_file)
             elif current_value:
                 settings.set(self.KEY, current_value)
+            sublime.save_settings(settings_file)
 
         def on_highlight(index):
             settings.set(self.KEY, values[index])


### PR DESCRIPTION
SublimeLinter dynamically modifies the "color_scheme" and saves the Preferences.sublime-settings each time a color scheme is highlighted (previewed).

As a result we need to save it, too, after restoring the old color scheme incase user cancels color theme selection. Otherwise the most recently highlighted (previewed) color scheme will suddenly be active upon next start of Sublime Text.

Sorry, did not realize it.