### PR TITLE
Add renamed 'zzz A File Icon zzz' package to list of excluded filters.

### DIFF
--- a/Theme-Switcher.sublime-settings
+++ b/Theme-Switcher.sublime-settings
@@ -11,6 +11,7 @@
 	// This setting is mainly used to hide dynamically created themes.
 	"themes_exclude":
 	[
-		"Packages/zz File Icons/"
+		"Packages/zz File Icons/",
+		"Packages/zzz A File Icon zzz/"
 	]
 }


### PR DESCRIPTION
The 'zz File Icons' package was recently renamed to 'zzz A File Icon zzz', so
we might add it to the default list of excluded themes to help users not to need to
struggle with the settings file.