### PR TITLE
A set of enhencements

### DIFF
--- a/theme_switcher.py
+++ b/theme_switcher.py
@@ -83,6 +83,12 @@ class SwitchWindowCommandBase(sublime_plugin.WindowCommand):
 
     PREFS_FILE = 'Preferences.sublime-settings'
 
+    # A set of tuples (settings, original) with view specific color schemes or
+    # themes which need to be restored after all as this command intends to
+    # apply the global color scheme or theme only but applies preview to all
+    # views no matter they use their own settings or not.
+    overridden = set()
+
     # The last selected row index - used to debounce the search so we
     # aren't apply a new color scheme or theme with every keypress
     last_index = -1
@@ -110,9 +116,12 @@ class SwitchWindowCommandBase(sublime_plugin.WindowCommand):
         selected_index = self.get_selected(values, current_value)
 
         def on_select(index):
+            # reset all view specific settings to initial values
+            self.reset_overridden()
+            # apply global settings
             if -1 < index < len(values):
                 settings.set(self.KEY, values[index])
-            elif current_value:
+            else:
                 settings.set(self.KEY, current_value)
             sublime.save_settings(self.PREFS_FILE)
 
@@ -125,12 +134,30 @@ class SwitchWindowCommandBase(sublime_plugin.WindowCommand):
             def update_ui():
                 if index != self.last_index:
                     return
-                settings.set(self.KEY, values[index])
+                value = values[index]
+                if settings.get(self.KEY) == value:
+                    return
+                # apply value to global settings
+                settings.set(self.KEY, value)
+                # apply value to overridden views
+                if not self.overridden:
+                    self.find_overridden(value)
+                for view_setting, _ in self.overridden:
+                    view_setting.set(self.KEY, value)
+
             sublime.set_timeout(update_ui, 250)
 
         self.window.show_quick_panel(
             items=names, selected_index=selected_index,
             on_highlight=on_highlight, on_select=on_select)
+
+    def find_overridden(self, global_value):
+        """Find view specific settings and their initial values."""
+        return None
+
+    def reset_overridden(self):
+        """Reset view specific settings to their initial values."""
+        self.overridden.clear()
 
 
 class SwitchThemeCommand(SwitchWindowCommandBase):
@@ -227,3 +254,43 @@ class SwitchColorSchemeCommand(SwitchWindowCommandBase):
             except ValueError:
                 selected_index = -1
         return selected_index
+
+    def find_overridden(self, global_cs):
+        """Create a set of view specific color schemes and their defaults.
+
+        Arguments:
+            global_cs (string):
+                the global color scheme from Preferences.sublime-settings
+
+        Returns:
+            tuple (settings, original)
+             - settings (sublime.Settings): the view settings object
+             - original (string): the original "color_scheme" for the view
+        """
+        project = self.window.project_data()
+        pcs = project.get('settings', {}).get(self.KEY) if project else None
+        for i in range(self.window.num_groups()):
+            view = self.window.active_view_in_group(i)
+            view_settings = view.settings()
+            vcs = view_settings.get(self.KEY, self.DEFAULT)
+            if pcs is not None:
+                # view shows project specific setting
+                # needs to be deleted after all
+                if vcs == pcs and pcs != global_cs:
+                    self.overridden.add((view_settings, None))
+                    continue
+            if vcs != global_cs:
+                # view shows view specific setting
+                # needs to be reset to default value after all
+                self.overridden.add((view_settings, vcs))
+
+    def reset_overridden(self):
+        """Reset view specific settings to their initial values."""
+        for settings, original in self.overridden:
+            if original is None:
+                # apply project specific values
+                settings.erase(self.KEY)
+            else:
+                # apply view specific values
+                settings.set(self.KEY, original)
+        super().reset_overridden()

--- a/theme_switcher.py
+++ b/theme_switcher.py
@@ -83,6 +83,10 @@ class SwitchWindowCommandBase(sublime_plugin.WindowCommand):
 
     PREFS_FILE = 'Preferences.sublime-settings'
 
+    # The last selected row index - used to debounce the search so we
+    # aren't apply a new color scheme or theme with every keypress
+    last_index = -1
+
     def run(self, name=None):
         """API entry point for command execution."""
         if name:
@@ -113,7 +117,16 @@ class SwitchWindowCommandBase(sublime_plugin.WindowCommand):
             sublime.save_settings(self.PREFS_FILE)
 
         def on_highlight(index):
-            settings.set(self.KEY, values[index])
+            if index == -1:
+                return
+
+            self.last_index = index
+
+            def update_ui():
+                if index != self.last_index:
+                    return
+                settings.set(self.KEY, values[index])
+            sublime.set_timeout(update_ui, 250)
 
         self.window.show_quick_panel(
             items=names, selected_index=selected_index,

--- a/theme_switcher.py
+++ b/theme_switcher.py
@@ -11,7 +11,7 @@ def menu_cache_path():
 def built_res_name(pkg_name):
     """Built menu or quick panel item name from a resource file name."""
     name, _ = os.path.splitext(os.path.basename(pkg_name))
-    return name.replace("-", " ").replace(".", " ")
+    return name.replace(" - ", " ").replace("-", " ").replace(".", " ")
 
 
 def plugin_loaded():
@@ -153,7 +153,7 @@ class SwitchThemeCommand(SwitchWindowCommandBase):
         exclude_list = settings.get("themes_exclude") or []
         paths = sorted(
             sublime.find_resources("*.sublime-theme"),
-            key=lambda x: os.path.basename(x))
+            key=lambda x: os.path.basename(x).lower())
         for path in paths:
             if not any(exclude in path for exclude in exclude_list):
                 elems = path.split("/")
@@ -195,7 +195,7 @@ class SwitchColorSchemeCommand(SwitchWindowCommandBase):
         exclude_list = settings.get("colors_exclude") or []
         paths = sorted(
             sublime.find_resources("*.tmTheme"),
-            key=lambda x: os.path.basename(x))
+            key=lambda x: os.path.basename(x).lower())
         for path in paths:
             if not any(exclude in path for exclude in exclude_list):
                 elems = path.split("/")

--- a/theme_switcher.py
+++ b/theme_switcher.py
@@ -183,13 +183,17 @@ class SwitchThemeCommand(SwitchWindowCommandBase):
             key=lambda x: os.path.basename(x).lower())
         for path in paths:
             if not any(exclude in path for exclude in exclude_list):
-                elems = path.split("/")
-                # elems[1] package name
-                # elems[-1] theme file name
+                parts = path.split("/")
+                theme = parts[-1]
+                # themes are merged by ST so display only first one
+                if theme in values:
+                    continue
+                # parts[1] package name
+                # parts[-1] theme file name
                 names.append(
-                    [built_res_name(elems[-1]),    # title
-                     "Package: " + elems[1]])      # description
-                values.append(elems[-1])
+                    [built_res_name(theme),       # title
+                     "Package: " + parts[1]])     # description
+                values.append(theme)
         return [names, values]
 
     @staticmethod


### PR DESCRIPTION
I ported some interesting features/improvements from ST's UI module of the _Default.sublime-package_ to improve this plugin.

1. Use a 250ms timer to debounce the preview
2. Apply preview also to views with view specific color schemes
3. Sort the quick panel case insensitive as it seems to make more sense.
4. Fix issue with duplicated themes being displayed in the quick panel.

Hope you'll find these changes useful, too.