### PR TITLE
Fix: Avoid exception if no SublimeLinter color schemes are found

### DIFF
--- a/theme_switcher.py
+++ b/theme_switcher.py
@@ -276,7 +276,7 @@ class SwitchColorSchemeCommand(SwitchWindowCommandBase):
                 original_scheme = os.path.basename(original_scheme)
                 original_scheme = sublime.find_resources(original_scheme)[-1]
                 selected_index = values.index(original_scheme)
-            except ValueError:
+            except (IndexError, ValueError):
                 selected_index = -1
         return selected_index
 


### PR DESCRIPTION
If `sublime.find_resources()` returns an empty list, an `IndexError` is raised which needs to be catched.