### PR TITLE
Hide Widget Color Schemes

### DIFF
--- a/Theme-Switcher.sublime-settings
+++ b/Theme-Switcher.sublime-settings
@@ -4,7 +4,8 @@
 	"colors_exclude":
 	[
 		"Packages/User/SublimeLinter",
-		"Packages/User/Sublimerge"
+		"Packages/User/Sublimerge",
+		"Widget - "
 	],
 
 	// Ignore themes whose path include one of the listed strings.


### PR DESCRIPTION
Packages can provide an "Widget - ThemeName.sublime-color-scheme" file in order to add special color schemes for ST's widgets such as find panels, etc.

We might not want to display them in the list of normal color schemes.